### PR TITLE
Simplified the usage by providing methods to easily prepare and send the post request

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# ATTENTION!
+
+This is a fork of [php-mutlipart-form-data-builder](https://github.com/multiline-amio/php-mutlipart-form-data-builder) under development for impruvements.
+
+Do not use it in production, refer to [the original repository](https://github.com/multiline-amio/php-mutlipart-form-data-builder) instead.
+
 # PHP Mutlipart Form Data Builder
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/multiline-amio/php-mutlipart-form-data-builder.svg?style=flat-square)](https://packagist.org/packages/multiline-amio/php-mutlipart-form-data-builder)
@@ -8,7 +14,7 @@
 You can install the package via composer:
 
 ```bash
-composer require multiline-amio/php-mutlipart-form-data-builder
+composer require emanuele-scarsella/php-mutlipart-form-data-builder
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -1,9 +1,3 @@
-# ATTENTION!
-
-This is a fork of [php-mutlipart-form-data-builder](https://github.com/multiline-amio/php-mutlipart-form-data-builder) under development for impruvements.
-
-Do not use it in production, refer to [the original repository](https://github.com/multiline-amio/php-mutlipart-form-data-builder) instead.
-
 # PHP Mutlipart Form Data Builder
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/multiline-amio/php-mutlipart-form-data-builder.svg?style=flat-square)](https://packagist.org/packages/multiline-amio/php-mutlipart-form-data-builder)
@@ -14,7 +8,7 @@ Do not use it in production, refer to [the original repository](https://github.c
 You can install the package via composer:
 
 ```bash
-composer require emanuele-scarsella/php-mutlipart-form-data-builder
+composer require multiline-amio/php-mutlipart-form-data-builder
 ```
 
 ## Usage

--- a/example/sender.php
+++ b/example/sender.php
@@ -14,31 +14,7 @@ try {
         ->addData('fed[]', 'def')
         ->addFile('file[]', __DIR__ . '/receiver.php')
         ->addFile('file[]', __DIR__ . '/sender.php')
-        ->build();
+        ->send("http://localhost/receiver.php");
 } catch (FormDataBuilderException $e) {
     die($e->getMessage());
-}
-
-$host = "localhost";
-$path = "/receiver.php";
-$fp = fsockopen($host, 8888);
-if ($fp) {
-    $str = "POST " . $path . " HTTP/1.1\r\n";
-    $str .= "Host: " . $host . "\r\n";
-    $str .= "Content-Type: " . $formDataBuilder->getContentType() . "\r\n";
-    $str .= "Content-Length: " . strlen($data) . "\r\n";
-    $str .= "Connection: close\r\n\r\n";
-
-    $str .= $data;
-
-    fwrite($fp, $str);
-
-    $result = '';
-    while (!feof($fp)) {
-        $result .= fgets($fp, 128);
-    }
-    fclose($fp);
-
-    $response = explode("\r\n\r\n", $result);
-    echo $response[1];
 }


### PR DESCRIPTION
By adding two methods (`addHeader` and `send`) inside the `FormDataBuilder` class it is possible to streamline the steps required to send the content through a POST request.
